### PR TITLE
Create zh_CN.lang

### DIFF
--- a/src/main/resources/assets/immersivepetroleum/lang/zh_CN.lang
+++ b/src/main/resources/assets/immersivepetroleum/lang/zh_CN.lang
@@ -1,0 +1,40 @@
+tile.immersivepetroleum.fluid_diesel.name=柴油
+tile.immersivepetroleum.fluid_crude_oil.name=原油
+
+tile.immersivepetroleum.stone_decoration.asphalt.name=沥青混凝土
+
+chat.immersivepetroleum.info.coresample.oil=%s mB 原油
+chat.immersivepetroleum.info.coresample.noOil=没有原油
+
+fluid.diesel=柴油
+fluid.oil=原油
+
+item.immersivepetroleum.material.bitumen.name=沥青
+item.immersivepetroleum.material.petcoke.name=石油焦
+
+# itemGroup.immersivepetroleum=Immersive Petroleum
+
+# ie.manual.entry.blank_text=
+
+desc.immersiveengineering.info.multiblock.IP:DistillationTower=蒸馏塔
+
+ie.manual.entry.distillationTower.name=蒸馏塔
+ie.manual.entry.distillationTower.subtext=环境不友好
+ie.manual.entry.distillationTower0=蒸馏塔是能将石油分馏成若干种产品的大型多方块设备。其结构如下图所示；需要用工程师锤敲击红石工程块完成建造。<br><br>原油可从其后面带有蓝点的输入端输入。原油在塔中会被加热，最终分成若干层不同的产物。这个过程会产出柴油，以及作为副产物存在的沥青。
+ie.manual.entry.distillationTower1=蒸馏塔每次运行会消耗<config;i;distillationTower_operationCost> Flux，每刻最多将 25 mB 原油转化为柴油。柴油会从侧面带有橙色点标记的输出端输出；副产物沥青则从正面输出。这些产物分别可用于 <link;dieselgen;§o§n柴油发电机§r>和<link;asphalt;§o§n沥青混凝土的制造§r>。<br><br>给予控制面板红石信号可令其暂停工作；此效果可用工程师锤反转。
+
+ie.manual.entry.pumpjack.name=抽油泵
+ie.manual.entry.pumpjack.subtext=Pump, pump it up
+ie.manual.entry.pumpjack0=抽油泵可将蕴藏于基岩层中的石油储藏抽出。它本身有多方块结构；搭建完成后，需要用工程师锤敲击第二层中的重型工程块来完成建造。
+ie.manual.entry.pumpjack1=抽油泵的产油速度为 <config;i;pumpjack_speed> mB/t，功耗则为 <config;i;pumpjack_consumption> Flux/t。抽出的原油可从侧面的两个输出端（以橙色点标注）自动输出。<br><br>一般，原油储藏会在一台泵连续工作 <config;i;pumpjack_days> 天后枯竭。自然地，使用多台泵会加快其枯竭速度。<br><br>给予控制面板红石信号可令其暂停工作；此效果可用工程师锤反转。
+
+ie.manual.entry.oil.name=油藏
+ie.manual.entry.oil.subtext=黑金
+ie.manual.entry.oil0=你在基岩层附近挖矿时，偶然注意到了一些粘稠的黑色可燃物质。你提出了“那层不可破坏的岩层下还有更多石油储藏”的假设，但很明显，你已无法钻探到更深的地方了。但在<link;pumpjack;§o§n特殊设计的设备§r>的帮助下，你最终终于触碰到了哪些宝贵的燃料来源。
+ie.manual.entry.oil1=<link;minerals;§o§n岩芯钻井§r>可以探明某区块内是否有石油储藏及具体储量。<br><br>尽管油田会枯竭，抽油泵仍能从枯竭的油田中抽出少量石油（最多 <config;i;oil_replenish> mB/t）。需要注意的是，用多台抽油泵并不能提高枯竭的油田的产量。
+
+ie.manual.entry.asphalt.name=沥青混凝土
+ie.manual.entry.asphalt.subtext=高速公路
+ie.manual.entry.asphalt0=沥青混凝土，顾名思义，是掺有粘稠的沥青的混凝土，也因此其颜色比普通混凝土更深。它本身可作为<link;distillationTower;§n§o蒸馏塔§r>处理原油时的副产物出现。
+
+ie.manual.category.ip.name=原油处理


### PR DESCRIPTION
1.11 counterpart of #1

Named in `zh_CN.lang` to match that `en_US.lang`. Shouldn't that be `en_us.lang`? I know there is legacy v2 resourcepack adapter, but that may not be a thing in future.