### PR TITLE
Fixed the Engineer's Manual

### DIFF
--- a/src/main/java/flaxbeard/immersivepetroleum/ImmersivePetroleum.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/ImmersivePetroleum.java
@@ -8,7 +8,6 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeModContainer;
-import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.UniversalBucket;
@@ -93,8 +92,6 @@ public class ImmersivePetroleum
 		IPContent.init();
 		NetworkRegistry.INSTANCE.registerGuiHandler(INSTANCE, proxy);
 		proxy.init();
-		
-		MinecraftForge.EVENT_BUS.register(new EventHandler());
 	}
 	
 	@Mod.EventHandler


### PR DESCRIPTION
Simple patch that corrects the crash that is caused from attempting to close the Engineer's Manual from IE.
Also, simplified how Forge registers the EventHandler.

See here [`Forge Wiki`](https://mcforge.readthedocs.io/en/latest/events/intro/#creating-an-event-handler).