### PR TITLE
Full localized zh_CN language file

### DIFF
--- a/src/main/resources/assets/immersivepetroleum/lang/zh_CN.lang
+++ b/src/main/resources/assets/immersivepetroleum/lang/zh_CN.lang
@@ -1,40 +1,143 @@
 tile.immersivepetroleum.fluid_diesel.name=柴油
 tile.immersivepetroleum.fluid_crude_oil.name=原油
+tile.immersivepetroleum.fluid_lubricant.name=润滑油
+tile.immersivepetroleum.fluid_gasoline.name=汽油
 
 tile.immersivepetroleum.stone_decoration.asphalt.name=沥青混凝土
 
-chat.immersivepetroleum.info.coresample.oil=%s mB 原油
+tile.immersivepetroleum.metal_device.automatic_lubricator.name=自动润滑机
+tile.immersivepetroleum.metal_device.gas_generator.name=便携发电机
+
+tile.immersivepetroleum.metal_multiblock.pumpjack.name=抽油机
+tile.immersivepetroleum.metal_multiblock.distillation_tower.name=精馏塔
+tile.immersivepetroleum.metal_multiblock.pumpjack_parent.name=抽油机
+tile.immersivepetroleum.metal_multiblock.distillation_tower_parent.name=精馏塔
+
+chat.immersivepetroleum.info.coresample.oil=%s mB %s
 chat.immersivepetroleum.info.coresample.noOil=没有原油
+chat.immersivepetroleum.info.coresample.oilRep=Up to %d mB/tick of trace %s
+chat.immersivepetroleum.info.schematic.noMultiblock=使用工程师手册合成
+chat.immersivepetroleum.info.schematic.build0=显示搭建
+chat.immersivepetroleum.info.schematic.build1=%s 的提示
+chat.immersivepetroleum.info.schematic.center=中心位置 (%d, %d, %d)
+chat.immersivepetroleum.info.schematic.controls=%s 旋转, %s + %s 镜像翻转
 
 fluid.diesel=柴油
 fluid.oil=原油
+fluid.lubricant=润滑油
+fluid.gasoline=汽油
 
 item.immersivepetroleum.material.bitumen.name=沥青
 item.immersivepetroleum.material.petcoke.name=石油焦
+item.immersivepetroleum.upgrades.reinforced_hull.name=强化船壳
+item.immersivepetroleum.upgrades.icebreaker.name=破冰船弓
+item.immersivepetroleum.upgrades.tank.name=扩充油箱
+item.immersivepetroleum.upgrades.rudders.name=机动方向舵
+item.immersivepetroleum.upgrades.paddles.name=应急船桨
 
-# itemGroup.immersivepetroleum=Immersive Petroleum
+item.immersivepetroleum.schematic.name=%s 投影仪
 
-# ie.manual.entry.blank_text=
+item.immersivepetroleum.speedboat.name=摩托艇
+
+item.immersivepetroleum.oil_can.name=润滑油罐
+
+itemGroup.immersivepetroleum=Immersive Petroleum
+#itemGroup.immersivepetroleum=沉浸石油工艺
+
+ie.manual.entry.blank_text=
 
 desc.immersiveengineering.info.multiblock.IP:DistillationTower=精馏塔
+desc.immersiveengineering.info.multiblock.IP:Pumpjack=抽油机
+desc.immersiveengineering.info.multiblock.IE:AutoWorkbench=自动装配台
+desc.immersiveengineering.info.multiblock.IE:AlloySmelter=合金冶炼厂
+
+desc.immersivepetroleum.info.reservoir.oil=油田
+desc.immersivepetroleum.info.reservoir.aquifer=蓄水层
+desc.immersivepetroleum.info.reservoir.lava=岩浆房
+
+desc.immersivepetroleum.flavour.upgrades.reinforced_hull=提升摩托艇生命值，获得抗火能力
+desc.immersivepetroleum.flavour.upgrades.icebreaker=使摩托艇能够破冰，对怪物造成伤害
+desc.immersivepetroleum.flavour.upgrades.tank=增加摩托艇油箱容量
+desc.immersivepetroleum.flavour.upgrades.rudders=允许摩托艇转更急的弯
+desc.immersivepetroleum.flavour.upgrades.paddles=燃料耗尽时允许用手划
+
+
 
 ie.manual.entry.distillationTower.name=精馏塔
 ie.manual.entry.distillationTower.subtext=环境不友好
-ie.manual.entry.distillationTower0=精馏塔是能将石油分馏成若干种产品的大型多方块设备。其结构如下图所示；需要用工程师锤敲击红石工程块完成建造。<br><br>原油可从其后面带有蓝点的输入端输入。原油在塔中会被加热，最终分成若干层不同的产物。这个过程会产出柴油，以及作为副产物存在的沥青。
-ie.manual.entry.distillationTower1=精馏塔每次运行会消耗<config;i;distillationTower_operationCost> Flux，每刻最多将 25 mB 原油转化为柴油。柴油会从侧面带有橙色点标记的输出端输出；副产物沥青则从正面输出。这些产物分别可用于 <link;dieselgen;§o§n柴油发电机§r>和<link;asphalt;§o§n沥青混凝土的制造§r>。<br><br>给予控制面板红石信号可令其暂停工作；此效果可用工程师锤反转。
+ie.manual.entry.distillationTower0=精馏塔是能将原油分馏成若干种产品的大型多方块设备。其结构如下图所示；需要用工程师锤敲击红石工程块完成建造。<br><br>原油可从其后面带有蓝点的输入端输入。原油在塔中会被加热，最终分成若干层不同的液体，有一定机率产出沥青作为副产物。
+ie.manual.entry.distillationTower1=精馏塔每次运行会消耗<config;i;distillationTower_operationCost>Flux，每刻最多将 25 mB 原油转化为柴油、润滑油、汽油和沥青。这些液体会从侧面带有橙色点标记的输出端输出，沥青则从正面输出。<br><br>柴油可用于<link;dieselgen;§o§n柴油发电机§r>，润滑油可用于<link;lubricant;§o§n润滑机器§r>，汽油可用于<link;portableGenerator;§o§n供给发电机§r>或者<link;speedboat;§o§n交通工具§r>。沥青可用于制作<link;asphalt;§o§n沥青混凝土§r>。
+ie.manual.entry.distillationTower2=以下是精馏塔能进行的转化操作：
 
 ie.manual.entry.pumpjack.name=采油机
-ie.manual.entry.pumpjack.subtext=Pump, pump it up
-ie.manual.entry.pumpjack0=采油机可将蕴藏于基岩层中的石油储藏抽出。它本身有多方块结构；搭建完成后，需要用工程师锤敲击第二层中的重型工程块来完成建造。
-ie.manual.entry.pumpjack1=采油机的产油速度为 <config;i;pumpjack_speed> mB/t，功耗则为 <config;i;pumpjack_consumption> Flux/t。抽出的原油可从侧面的两个输出端（以橙色点标注）自动输出。<br><br>一般，原油储藏会在一台泵连续工作 <config;i;pumpjack_days> 天后枯竭。自然地，使用多台泵会加快其枯竭速度。<br><br>给予控制面板红石信号可令其暂停工作；此效果可用工程师锤反转。
+ie.manual.entry.pumpjack.subtext=抽起，搞起！
+ie.manual.entry.pumpjack0=采油机是一个多方块结构，能把基岩下的原油储藏抽出来。搭建完成后，需要用工程师锤敲击第二层的重型工程块来完成建造。
+ie.manual.entry.pumpjack1=采油机的产油速度为<config;i;pumpjack_speed>mB/t，功耗为<config;i;pumpjack_consumption>Flux/t。抽出的原油可从侧面的两个输出端（以橙色点标注）自动输出。<br><br>一般，原油储藏会在一台泵连续工作<config;i;pumpjack_days>天后枯竭。自然地，使用多台泵会加快其枯竭速度。<br><br>给予控制面板红石信号可令其暂停工作；此效果可用工程师锤反转。
 
 ie.manual.entry.oil.name=油藏
 ie.manual.entry.oil.subtext=黑金
-ie.manual.entry.oil0=你在基岩层附近挖矿时，偶然注意到了一些粘稠的黑色可燃物质。你提出了“那层不可破坏的岩层下还有更多石油储藏”的假设，但很明显，你已无法钻探到更深的地方了。但在<link;pumpjack;§o§n特殊设计的设备§r>的帮助下，你最终终于触碰到了哪些宝贵的燃料来源。
-ie.manual.entry.oil1=<link;minerals;§o§n岩芯钻井§r>可以探明某区块内是否有石油储藏及具体储量。<br><br>尽管油田会枯竭，采油机仍能从枯竭的油田中抽出少量石油（最多 <config;i;oil_replenish> mB/t）。需要注意的是，用多台采油机并不能提高枯竭的油田的产量。
+ie.manual.entry.oil0=在基岩层附近挖矿时，你有时会发现一些粘稠的黑色可燃物质：石油。石油只是那层坚不可破的岩层下蕴藏的多种液体之一，可是仅凭自己，你根本打不破这层屏障。<br><br>在<link;pumpjack;§o§n特殊设计的设备§r>的帮助下，你终于能亲手触碰到这些矿藏。
+ie.manual.entry.oil1=<link;minerals;§o§n岩芯钻井§r>可以探明某区块内是否有石油储藏及具体藏量。<br><br>虽然每个区块内的藏油量是确定的，但有些油田在枯竭后也能开采出少量原油。当然，用多台采油机并不能提高枯竭油田的产量。
+ie.manual.entry.oil2=%1$s %6$s<br>含有 %3$s 到 %4$s mB %2$s.%5$s
+ie.manual.entry.oilConsonant=
+ie.manual.entry.oilVowel=
+ie.manual.entry.oilDimValid=%3$s §l%1$s§r 分布于 %2$s。
+ie.manual.entry.oilDimInvalid=%3$s §l%1$s§r 在除 %2$s 外所有维度都有分布。
+ie.manual.entry.oilDimAny=%2$s §l%1$s§r 在所有维度都有分布。
+ie.manual.entry.oilReplenish=<br>矿藏枯竭后，单个抽油机能以 %1$d mB/tick 速度抽取少量 %2$s。
+ie.manual.entry.oilBiomeValid=生成于 %s。
+ie.manual.entry.oilBiomeInvalid=除 %s 外所有生物群系都会生成。
+ie.manual.entry.oilBiomeAny=所有生物群系都会生成。
 
 ie.manual.entry.asphalt.name=沥青混凝土
-ie.manual.entry.asphalt.subtext=高速公路
-ie.manual.entry.asphalt0=沥青混凝土，顾名思义，是掺有粘稠的沥青的混凝土，也因此其颜色比普通混凝土更深。它本身可作为<link;distillationTower;§n§o精馏塔§r>处理原油时的副产物出现。
+ie.manual.entry.asphalt.subtext=高速公路的材料
+ie.manual.entry.asphalt0=沥青混凝土，顾名思义，是掺有粘稠的沥青的混凝土，也因此其颜色比普通混凝土更深。使用<link;distillationTower;§n§o精馏塔§r>处理原油的副产物制作。
 
-ie.manual.category.ip.name=原油处理
+ie.manual.entry.schematics.name=多方块投影仪
+ie.manual.entry.schematics.subtext=无价的指导
+ie.manual.entry.schematics0=搭建大型多方块结构时，一次又一次打开工程师手册简直能把人麻烦死。但现在，你只需要合成一个简单的投影仪，就能把多方块结构的蓝图投射出来，作为搭建的模板。
+ie.manual.entry.schematics1=把工程师手册翻到多方块结构的一页，与投影仪一起放在工作台里合成，投影仪将与工程师手册内的结构相匹配，投射出三维的搭建指导框架。
+ie.manual.entry.schematics2=把投影仪拿在手上将投影出多方块结构。按鼠标中键可旋转结构，Shift+鼠标中键可镜像翻转结构。右键可以把结构固定在地面上，这时要求投影仪放在快捷栏中，否则结构蓝图将消失。<br><br>拿着投影仪 Shift+右键可以取消固定在地面上的结构蓝图。<br><br>创造模式下，Shift+右键把结构蓝图固定在地面上时，会自动建造多方块结构。
+
+ie.manual.entry.speedboat.name=摩托艇
+ie.manual.entry.speedboat.subtext=弄潮儿
+ie.manual.entry.speedboat0=现在，你能骑着摩托艇在大海里和乘风破浪啦！摩托艇行驶时需要<link;distillationTower;§n§o汽油§r>作为燃料，可以用桶或<link;jerrycan;§n§o油罐§r>加入。按住空格键可加速，同时也会增加燃料消耗，增大转弯半径。
+ie.manual.entry.speedboat1=与其他设备类似，摩托艇可以放在<link;workbench;§o§n工程师装配台§r>中改装。<br><br>加装 §6扩充油箱§r 可以使摩托艇的油箱容量翻倍。
+ie.manual.entry.speedboat2=加装 §6机动方向舵§r 能让摩托艇转向更灵活，大大提升可操作性。添加这个升级后，摩托艇的转弯半径将明显减小。
+ie.manual.entry.speedboat3=加装了 §6破冰船弓§r，摩托艇能冲破冰层，在气候寒冷的水域里无往而不利。有了机动性的加持，摩托艇能对撞到的生物造成伤害。
+ie.manual.entry.speedboat4=如果你想探索未知的领域，或者仅仅想让摩托艇更坚固，就考虑加装一个 §6强化船壳§r 吧。钢制的船壳不仅提高了摩托艇的生命值，还强化了抗火能力，让你能行驶在地狱岩浆湖里。
+ie.manual.entry.speedboat5=给你的摩托艇加装一对 §6应急船桨§r，就不用再担心燃料耗尽了。一旦船上的燃料用尽，你还能像原版的船一样用桨划行。
+
+ie.manual.entry.lubricant.name=润滑油
+ie.manual.entry.lubricant.subtext=滑呀滑
+ie.manual.entry.lubricant0=没有机器是完美的，你的也是一样。运行时，不可避免的摩擦力让机器难以发挥出最好状态，这时润滑油就派上用场了——它能让机器全速运转，达到基础速度的<config;d;autoLubricant_speedup>倍。<br><br><link;pumpjack;§n§o抽油机§r>、<link;excavator;§n§o斗轮式挖掘机§r>和<link;crusher;§n§o粉碎机§r>都可以使用润滑油。
+ie.manual.entry.lubricant1=使用润滑油罐，可以手动给机器加润滑油。润滑油效果最好，不过用<link;squeezer;§n§o植物油§r>也行。机器润滑加速时，可以看到油滴效果。
+ie.manual.entry.lubricant2=润滑油还能润滑铁傀儡，在回复生命值的同时，还能暂时提升速度和力量。<br><br><link;chemthrower;§o§n化学喷射器§r>也能用来润滑，就是效果不太好。把润滑剂喷在机器上，就能让机器全速运转。
+
+ie.manual.entry.automaticLubricator.name=自动润滑机
+ie.manual.entry.automaticLubricator.subtext=解放双手
+ie.manual.entry.automaticLubricator0=手工给机器加<link;distillationTower;§n§o润滑油§r>是个累活，不如在机器旁加一个自动润滑机，由它代劳添加润滑油。<br><br>把自动润滑机拿在手上时，机器旁会高亮显示应该放置的位置。
+ie.manual.entry.automaticLubricator1=一旦润滑油放置正确，会有一根管子出现在机器上。这时再添加润滑油或<link;squeezer;§n§o植物油§r>即可。
+
+ie.manual.entry.portableGenerator.name=便携发电机
+ie.manual.entry.portableGenerator.subtext=加满油
+ie.manual.entry.portableGenerator0=便携发电机是一种一体化能量解决方案。这种机器使用<link;distillationTower;§n§o汽油§r>，产能速度最高达到<config;i;portableGenerator_flux>Flux/t，内部拥有 100,000RF 的能量缓冲。
+ie.manual.entry.portableGenerator1=用桶右击便携发电机即可添加燃料，汽油和其他燃料可以从上面输入。能量可以直接通过低压线和中压线输出，不需要使用继电器。提供红石信号可以停止发电。<br><br>Shift+右击即可带走发电机，所有燃料和能量都会保留。
+
+ie.manual.category.ip.name=石油处理
+
+chat.immersivepetroleum.command.help.help=§6用途：/ip help <command> [sub-commands ...]§r<br>获取特定命令或子命令的更多信息
+chat.immersivepetroleum.command.reservoir.help=§6用途：/ip reservoir <list|get|set|setAmount|setCapacity>§r
+chat.immersivepetroleum.command.reservoir.list.help=§6用途：/ip reservoir list§r<br>列出所有注册的油藏种类
+chat.immersivepetroleum.command.reservoir.get.help=§6用途：/ip reservoir get§r<br>显示这个区块的油藏种类
+chat.immersivepetroleum.command.reservoir.set.help=§6用途：/ip reservoir set [reservoir]§r<br>设置这个区块的油藏种类，不加参数可重置油藏种类
+chat.immersivepetroleum.command.reservoir.setAmount.help=§6用途：/ip reservoir setAmount <number>§r<br>设置这个区块内剩余的油藏 mB 量
+chat.immersivepetroleum.command.reservoir.setCapacity.help=§6Usage: /ip reservoir setCapacity <number>§r<br>设置这个区块内油藏的最大 mB 量
+chat.immersivepetroleum.command.reservoir.get=区块内含：%1$s <br>重设为：%2$s <br>容量：%3$s
+chat.immersivepetroleum.command.reservoir.set.invalidReservoir=§c无效的油藏种类，'%1$s' 不是有效的油藏种类。使用 '/ip reservoir list' 获取所有可用的油藏种类§r
+chat.immersivepetroleum.command.reservoir.set.sucess=油藏种类已重设为 '%1$s'
+chat.immersivepetroleum.command.reservoir.set.clear=重设的油藏种类（%1$s）已清除
+chat.immersivepetroleum.command.reservoir.setAmount.NFE=错误，'%1$s' 不是有效的数字
+chat.immersivepetroleum.command.reservoir.setAmount.sucess=油藏量已设为 '%1$s'
+chat.immersivepetroleum.command.reservoir.setCapacity.NFE=错误，'%1$s' 不是有效的数字
+chat.immersivepetroleum.command.reservoir.setCapacity.sucess=最大油藏量已设为 '%1$s'


### PR DESCRIPTION
The old zh_CN.lang file was too old to use, many new contents wasn't tranlated.
I have translated all the new contents and fixed some bugs in old lang file.
All the translations were tested.

I gave a translation of mod's name but was not sure to apply it, so I put it below the English name as a comment.
> itemGroup.immersivepetroleum=Immersive Petroleum
> #itemGroup.immersivepetroleum=沉浸石油工艺

Waiting for a better name.