### PR TITLE
Fix #171, #122, #109 and misdone localization

### DIFF
--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/metal/TileEntityDistillationTower.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/metal/TileEntityDistillationTower.java
@@ -245,8 +245,9 @@ public class TileEntityDistillationTower extends TileEntityMultiblockMetal<TileE
 
 		}
 
+		int amount_prev = tanks[0].getFluidAmount();
 		ItemStack emptyContainer = Utils.drainFluidContainer(tanks[0], inventory.get(0), inventory.get(1), null);
-		if (!emptyContainer.isEmpty() && emptyContainer.getCount() > 0)
+		if (amount_prev != tanks[0].getFluidAmount())
 		{
 			if (!inventory.get(1).isEmpty() && OreDictionary.itemMatches(inventory.get(1), emptyContainer, true))
 				inventory.get(1).grow(emptyContainer.getCount());

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/metal/TileEntityDistillationTower.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/metal/TileEntityDistillationTower.java
@@ -212,7 +212,7 @@ public class TileEntityDistillationTower extends TileEntityMultiblockMetal<TileE
 				lastFluidOut = null;
 				if (targetFluidStack != null)
 				{
-					FluidStack out = Utils.copyFluidStackWithAmount(targetFluidStack, Math.min(targetFluidStack.amount, 80), false);
+					FluidStack out = Utils.copyFluidStackWithAmount(targetFluidStack, Math.min(targetFluidStack.amount, 100), false);
 					int accepted = output.fill(out, false);
 					if (accepted > 0)
 					{
@@ -227,7 +227,7 @@ public class TileEntityDistillationTower extends TileEntityMultiblockMetal<TileE
 						while (iterator.hasNext())
 						{
 							targetFluidStack = iterator.next();
-							out = Utils.copyFluidStackWithAmount(targetFluidStack, Math.min(targetFluidStack.amount, 80), false);
+							out = Utils.copyFluidStackWithAmount(targetFluidStack, Math.min(targetFluidStack.amount, 100), false);
 							accepted = output.fill(out, false);
 							if (accepted > 0)
 							{

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/multiblocks/MultiblockDistillationTower.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/multiblocks/MultiblockDistillationTower.java
@@ -331,7 +331,7 @@ public class MultiblockDistillationTower implements IMultiblock
 
 	static final IngredientStack[] materials = new IngredientStack[]{
 			new IngredientStack("scaffoldingSteel", 25),
-			new IngredientStack(new ItemStack(IEContent.blockMetalDecorationSlabs1, 33, BlockTypes_MetalDecoration1.STEEL_SCAFFOLDING_0.getMeta())),
+			new IngredientStack(new ItemStack(IEContent.blockMetalDecorationSlabs1, 30, BlockTypes_MetalDecoration1.STEEL_SCAFFOLDING_0.getMeta())),
 			new IngredientStack(new ItemStack(IEContent.blockMetalDevice1, 17, BlockTypes_MetalDevice1.FLUID_PIPE.getMeta())),
 			new IngredientStack(new ItemStack(IEContent.blockMetalDecoration0, 1, BlockTypes_MetalDecoration0.RS_ENGINEERING.getMeta())),
 			new IngredientStack(new ItemStack(IEContent.blockMetalDecoration0, 4, BlockTypes_MetalDecoration0.HEAVY_ENGINEERING.getMeta())),

--- a/src/main/resources/assets/immersivepetroleum/lang/en_us.lang
+++ b/src/main/resources/assets/immersivepetroleum/lang/en_us.lang
@@ -88,7 +88,7 @@ ie.manual.entry.oilDimInvalid=%3$s §l%1$s§r is a type of fluid reservoir that 
 ie.manual.entry.oilDimAny=%2$s §l%1$s§r is a type of fluid reservoir that can be found in any Dimension.
 ie.manual.entry.oilReplenish=<br>After the reservoir is depleted, %1$d mB/tick of trace %2$s can be extracted by a single Pumpjack.
 ie.manual.entry.oilBiomeValid=This reservoir will generate in %s Biomes.
-ie.manual.entry.oilBiomeInvalid=This reservoir will generate in %s Biomes.
+ie.manual.entry.oilBiomeInvalid=This reservoir will generate in any biome but %s Biomes.
 ie.manual.entry.oilBiomeAny=This reservoir will generate in any Biome.
 
 ie.manual.entry.asphalt.name=Asphalt Concrete


### PR DESCRIPTION
 - Changes incorrect 33x steel scaffolding slabs to 30x
 - Changes incorrect localization for biomedict blacklist to be "spawns in all biomes but [biome]" instead of "spawns in [biome]"
  - Fixes distillation tower problems with item consumption when fluid containers were consumed upon use